### PR TITLE
Arrows for Connections

### DIFF
--- a/Assets/TrafficSimulation/Scripts/Editor/TrafficEditor.cs
+++ b/Assets/TrafficSimulation/Scripts/Editor/TrafficEditor.cs
@@ -1,6 +1,7 @@
 ﻿// Traffic Simulation
 // https://github.com/mchrbn/unity-traffic-simulation
 
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
@@ -118,12 +119,38 @@ namespace TrafficSimulation{
         }
 
         public override void OnInspectorGUI(){
-
+            EditorGUI.BeginChangeCheck();
+            
             //Editor properties
             EditorGUILayout.LabelField("Guizmo Config", EditorStyles.boldLabel);
             wps.hideGuizmos = EditorGUILayout.Toggle("Hide Guizmos", wps.hideGuizmos);
+            
+            //ArrowDrawType selection
+            wps.arrowDrawType = (ArrowDraw) EditorGUILayout.EnumPopup("Arrow Draw Type", wps.arrowDrawType);
+            EditorGUI.indentLevel++;
+
+            switch (wps.arrowDrawType) {
+                case ArrowDraw.FixedCount:
+                    wps.arrowCount = Mathf.Max(1, EditorGUILayout.IntField("Count", wps.arrowCount));
+                    break;
+                case ArrowDraw.ByLength:
+                    wps.arrowDistance = EditorGUILayout.FloatField("Distance Between Arrows", wps.arrowDistance);
+                    break;
+                case ArrowDraw.Off:
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException();
+            }
+            
+            EditorGUI.indentLevel--;
+            
+            //System Config
+            EditorGUILayout.Space();
             EditorGUILayout.LabelField("System Config", EditorStyles.boldLabel);
             wps.segDetectThresh = EditorGUILayout.FloatField("Segment Detection Threshold", wps.segDetectThresh);
+            
+            //Helper
+            EditorGUILayout.Space();
             EditorGUILayout.HelpBox("Ctrl + Left Click to create a new segment\nShift + Left Click to create a new waypoint.\nAlt + Left Click to create a new intersection", MessageType.Info);
             EditorGUILayout.HelpBox("Reminder: The cars will follow the point depending on the sequence you added them. (go to the 1st waypoint added, then to the second, etc.)", MessageType.Info);
 
@@ -131,6 +158,11 @@ namespace TrafficSimulation{
             //Rename waypoints if some have been deleted
             if(GUILayout.Button("Re-Structure Traffic System")){
                 RestructureSystem();
+            }
+
+            //Repaint the scene if values have been edited
+            if (EditorGUI.EndChangeCheck()) {
+                SceneView.RepaintAll();
             }
 
             serializedObject.ApplyModifiedProperties();

--- a/Assets/TrafficSimulation/Scripts/Editor/TrafficEditor.cs
+++ b/Assets/TrafficSimulation/Scripts/Editor/TrafficEditor.cs
@@ -142,6 +142,11 @@ namespace TrafficSimulation{
                     throw new ArgumentOutOfRangeException();
             }
             
+            if (wps.arrowDrawType != ArrowDraw.Off) {
+                wps.arrowSizeWaypoint = EditorGUILayout.FloatField("Arrow Size Waypoint", wps.arrowSizeWaypoint);
+                wps.arrowSizeIntersection = EditorGUILayout.FloatField("Arrow Size Intersection", wps.arrowSizeIntersection);
+            }
+            
             EditorGUI.indentLevel--;
             
             //System Config

--- a/Assets/TrafficSimulation/Scripts/TrafficSystem.cs
+++ b/Assets/TrafficSimulation/Scripts/TrafficSystem.cs
@@ -13,6 +13,10 @@ namespace TrafficSimulation{
 
         public bool hideGuizmos = false;
         public float segDetectThresh = 0.1f;
+        public ArrowDraw arrowDrawType;
+        public int arrowCount = 1;
+        public float arrowDistance = 5;
+
         public List<Segment> segments = new List<Segment>();
         public List<Intersection> intersections = new List<Intersection>();
         public Segment curSegment = null;  
@@ -46,10 +50,40 @@ namespace TrafficSimulation{
                     // Gizmos.color = new Color(0f, 0f, 1f, (j + 1) / (float) segment.waypoints.Count);
                     // Gizmos.DrawSphere(p, .5f);
 
-                    //Draw line
-                    Gizmos.color = new Color(1f, 0f, 0f);
-                    if(pNext != Vector3.zero)
+                    
+                    if(pNext != Vector3.zero) {
+                        //Draw line
+                        Gizmos.color = new Color(1f, 0f, 0f);
                         Gizmos.DrawLine(p, pNext);
+                        
+                        int arrows = 0;
+                        
+                        //Set arrowCount based on arrowDrawType
+                        switch (arrowDrawType) {
+                            case ArrowDraw.FixedCount:
+                                arrows = arrowCount;
+                                break;
+                            case ArrowDraw.ByLength:
+                                //Minimum of one arrow
+                                arrows = Mathf.Max(1, (int) (Vector3.Distance(p, pNext) / arrowDistance));
+                                break;
+                            case ArrowDraw.Off:
+                                break;
+                            default:
+                                throw new ArgumentOutOfRangeException();
+                        }
+                        
+                        Vector3 forward = (p - pNext).normalized;
+                        Vector3 left = Quaternion.Euler(0, 45, 0) * forward;
+                        Vector3 right = Quaternion.Euler(0, -45, 0) * forward;
+                        
+                        //Draw arrows
+                        for (int i = 1; i < arrows + 1; i++) {
+                            Vector3 point = Vector3.Lerp(p, pNext, (float) i / (arrows + 1));
+                            Gizmos.DrawLine(point, point + left);
+                            Gizmos.DrawLine(point, point + right);
+                        }
+                    }
                 }
 
                 //Draw line linking segments
@@ -64,5 +98,9 @@ namespace TrafficSimulation{
                 }
             }
         }
+    }
+
+    public enum ArrowDraw {
+        FixedCount, ByLength, Off
     }
 }

--- a/Assets/TrafficSimulation/Scripts/TrafficSystem.cs
+++ b/Assets/TrafficSimulation/Scripts/TrafficSystem.cs
@@ -13,7 +13,7 @@ namespace TrafficSimulation{
 
         public bool hideGuizmos = false;
         public float segDetectThresh = 0.1f;
-        public ArrowDraw arrowDrawType;
+        public ArrowDraw arrowDrawType = ArrowDraw.ByLength;
         public int arrowCount = 1;
         public float arrowDistance = 5;
 
@@ -94,6 +94,15 @@ namespace TrafficSimulation{
 
                         Gizmos.color = new Color(1f, 1f, 0f);
                         Gizmos.DrawLine(p1, p2);
+
+                        //Draw arrow
+                        Vector3 center = (p1 + p2) / 2f;
+                        Vector3 forward = (p1 - p2).normalized * 0.5f;
+                        Vector3 left = Quaternion.Euler(0, 45, 0) * forward;
+                        Vector3 right = Quaternion.Euler(0, -45, 0) * forward;
+                        
+                        Gizmos.DrawLine(center, center + left);
+                        Gizmos.DrawLine(center, center + right);
                     }
                 }
             }

--- a/Assets/TrafficSimulation/Scripts/TrafficSystem.cs
+++ b/Assets/TrafficSimulation/Scripts/TrafficSystem.cs
@@ -16,7 +16,9 @@ namespace TrafficSimulation{
         public ArrowDraw arrowDrawType = ArrowDraw.ByLength;
         public int arrowCount = 1;
         public float arrowDistance = 5;
-
+        public float arrowSizeWaypoint = 1;
+        public float arrowSizeIntersection = 0.5f;
+        
         public List<Segment> segments = new List<Segment>();
         public List<Intersection> intersections = new List<Intersection>();
         public Segment curSegment = null;  
@@ -73,7 +75,7 @@ namespace TrafficSimulation{
                                 throw new ArgumentOutOfRangeException();
                         }
                         
-                        Vector3 forward = (p - pNext).normalized;
+                        Vector3 forward = (p - pNext).normalized * arrowSizeWaypoint;
                         Vector3 left = Quaternion.Euler(0, 45, 0) * forward;
                         Vector3 right = Quaternion.Euler(0, -45, 0) * forward;
                         
@@ -95,14 +97,16 @@ namespace TrafficSimulation{
                         Gizmos.color = new Color(1f, 1f, 0f);
                         Gizmos.DrawLine(p1, p2);
 
-                        //Draw arrow
-                        Vector3 center = (p1 + p2) / 2f;
-                        Vector3 forward = (p1 - p2).normalized * 0.5f;
-                        Vector3 left = Quaternion.Euler(0, 45, 0) * forward;
-                        Vector3 right = Quaternion.Euler(0, -45, 0) * forward;
-                        
-                        Gizmos.DrawLine(center, center + left);
-                        Gizmos.DrawLine(center, center + right);
+                        if (arrowDrawType != ArrowDraw.Off) {
+                            //Draw arrow
+                            Vector3 center = (p1 + p2) / 2f;
+                            Vector3 forward = (p1 - p2).normalized * arrowSizeIntersection;
+                            Vector3 left = Quaternion.Euler(0, 45, 0) * forward;
+                            Vector3 right = Quaternion.Euler(0, -45, 0) * forward;
+
+                            Gizmos.DrawLine(center, center + left);
+                            Gizmos.DrawLine(center, center + right);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
It was hard to tell in which direction the waypoints are linked, so I added arrows who show exactly this. 

They can be set in the Traffic-System component under the Gizmo Config. There are two main options, first set a fixed number of arrows for all connections, secondly set a distance so it depends on the distance of the two waypoints. Also, the size of the arrows can be set there.

![grafik](https://user-images.githubusercontent.com/39767545/75795174-3c724c80-5d72-11ea-98e5-52b3f226e048.png)
